### PR TITLE
BUG: sort null values properly

### DIFF
--- a/src/data/sort.js
+++ b/src/data/sort.js
@@ -3,9 +3,9 @@ import R from 'ramda';
 export default function sortRows(rows, sortColumn, sortDirection) {
     function comparer(a, b) {
         if (sortDirection === 'ASC') {
-            return (a[sortColumn] > b[sortColumn]) ? 1 : -1;
+            return (a[sortColumn] > b[sortColumn]) ? true : false;
         } else if (sortDirection === 'DESC') {
-            return (a[sortColumn] < b[sortColumn]) ? 1 : -1;
+            return (a[sortColumn] < b[sortColumn]) ? true : false;
         }
     }
 


### PR DESCRIPTION
Closes #58 

Changed `comparer` function defined in `sortRows` function to return a bool instead of 1, -1. This way, null values are stacked at the end or at the beginning, depending on `sortDirection`.   