### PR TITLE
package.json: update react-data-grid to 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,14 +31,15 @@
     "prop-types": "^15.5.9",
     "ramda": "^0.24.1",
     "react": "^15.5.4",
-    "react-data-grid": "^2.0.58",
-    "react-data-grid-addons": "^2.0.58",
+    "react-data-grid": "^5.0.3",
+    "react-data-grid-addons": "^5.0.3",
     "react-dom": "^15.5.4",
     "react-virtualized": "^9.9.0"
   },
   "devDependencies": {
     "dash-components-archetype-dev": "^0.2.7",
     "enzyme": "^2.8.2",
+    "immutable": "^3.8.2",
     "react-test-renderer": "^15.5.4"
   }
 }


### PR DESCRIPTION
Fixes an issue with Chrome where horizontal scrolling is broken.
Updating react-data-grid to a version that introduces scrolling fixes,
which is `5.0.1` will solve many scrolling issues, however npm resolves
to `5.0.3` so we'll bump to `5.0.3`.

We also include a dependency to 'immutable' because upstream relies on
it as a dev dependency, but when we build we must also require it as
well or the build will break.  For some reason npm doesn't do a good
enough job at figuring out transitive dependencies.

Signed-off-by: Jamie Couture <jamie@quandl.com>