### PR TITLE
datatable: introduce auto-width flag

### DIFF
--- a/dash_table_experiments/metadata.json
+++ b/dash_table_experiments/metadata.json
@@ -197,6 +197,17 @@
         "required": false,
         "description": "Column widths (in pixels) of each column"
       },
+      "autowidth_last_cell": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Allow callers to explicitly not set the last cell width, even if\ndefined, such that we allow react-table-grid to do the calculation.\nDefault false.",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
       "columns": {
         "type": {
           "name": "arrayOf",

--- a/src/components/DataTable.react.js
+++ b/src/components/DataTable.react.js
@@ -91,8 +91,14 @@ class DataTable extends Component {
             filterable: Boolean(props.filterable)
         }));
         if (props.column_widths) {
-            newState.columns.forEach((c, i) => {
-                c.width = props.column_widths[i];
+            newState.columns.forEach((c, i, a) => {
+                if (props.autowidth_last_cell) {
+                    if (i < a.length - 1) {
+                        c.width = props.column_widths[i];
+                    }
+                } else {
+                    c.width = props.column_widths[i];
+                }
             });
         }
 
@@ -380,6 +386,13 @@ DataTable.propTypes = {
     column_widths: PropTypes.arrayOf(PropTypes.number),
 
     /**
+     * Allow callers to explicitly not set the last cell width, even if
+     * defined, such that we allow react-table-grid to do the calculation.
+     * Default false.
+     */
+    autowidth_last_cell: PropTypes.bool,
+
+    /**
      * Order of columns. Note that the column names are specified in
      * `rows` but without order. This attribute allows you to specify
      * a custom order for your columns.
@@ -434,6 +447,7 @@ DataTable.defaultProps = {
     filterable: false,
     sortable: true,
     resizable: true,
+    autowidth_last_cell: false,
     filters: {},
     selected_row_indices: [],
     row_selectable: false,


### PR DESCRIPTION
Currently, DataTable provides a way for users to define column widths,
which is useful for flexibility.  However, when tables and pre-set
columns do not match up perfectly, the last column can fall short of the
calculated width of the table viewport.  Adding a new flag to allow
callers to skip setting the fixed width of the last column, such that it
will be calculated by react-table-grid instead, allowing it to be a sane
width.

Fixes an issue where setting fixed widths may cause last item to fall
short of calculated container.

Signed-off-by: Jamie Couture <jamie@quandl.com>